### PR TITLE
Validate Supabase URL to avoid invalid URL errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Create a `.env` file with the following:
 ```env
 VITE_OPENAI_API_KEY=your_openai_api_key
 VITE_ELEVENLABS_API_KEY=your_elevenlabs_api_key
-VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 ```
+`VITE_SUPABASE_URL` must include the protocol (`https://`) and point to your Supabase project URL.
 
 4. Start the development server:
 ```bash

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,13 +3,23 @@ import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
 // Use environment variables instead of hardcoded values
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ;
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_PUBLISHABLE_KEY) {
   throw new Error(
     'Missing Supabase configuration. ' +
     'Ensure VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY are set in your environment.'
+  );
+}
+
+try {
+  // Validate SUPABASE_URL to provide a clearer error when the value is malformed
+  // rather than letting the Supabase client throw a cryptic "Invalid URL" error.
+  new URL(SUPABASE_URL);
+} catch {
+  throw new Error(
+    'Invalid SUPABASE_URL. Make sure it is a fully qualified URL (e.g. https://xyz.supabase.co).'
   );
 }
 


### PR DESCRIPTION
## Summary
- validate `VITE_SUPABASE_URL` to give clearer error when it is malformed
- clarify README example for `VITE_SUPABASE_URL` and document that it must include `https://`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bd8067a08323b6747a56affaf3e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated environment variable setup instructions to clarify that the Supabase URL must include the protocol (e.g., https://) and provided a more explicit example.

- **Bug Fixes**
  - Improved error messaging for invalid Supabase URL configuration, ensuring clearer guidance if the URL is not fully qualified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->