### PR TITLE
Fix popover platform undefined error

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
-import { platform as domPlatform } from "@floating-ui/dom"
 
 import { cn } from "@/lib/utils"
 
@@ -18,7 +17,6 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       {...props}
-      platform={domPlatform}
       className={cn(
         "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className


### PR DESCRIPTION
## Summary
- remove custom `@floating-ui/dom` platform from Popover

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856599e0268832383c75276ca7ad824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Internal cleanup to remove unused imports and props, with no impact on visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->